### PR TITLE
Handle new scope name for C++

### DIFF
--- a/grammars/literate.cson
+++ b/grammars/literate.cson
@@ -305,11 +305,14 @@
         'name': 'entity.name.section.literate'
     'end': '^@\\s.*$'
     'name': 'markup.code.c++.literate'
-    'contentName': 'source.c++'
+    'contentName': 'source.cpp'
     'patterns': [
       { 'include': '#double_at' }
       { 'include': '#link1' }
       { 'include': '#link2' }
+      { 'include': 'source.cpp' }
+
+      # For backward-compatibility with Atom version < 0.166
       { 'include': 'source.c++' }
     ]
   }


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope names for C++ and Objective-C++ will change from `source.c++` and `source.objc++` to `source.cpp` and `source.objcpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Refs atom/language-c#54.
