### PR TITLE
Add Support for Lesen, Add Syntax Highlighting for <<...>>+=

### DIFF
--- a/grammars/gfm_literate.cson
+++ b/grammars/gfm_literate.cson
@@ -4,6 +4,8 @@
   'w'
   'nw'
   'noweb'
+  'lsn'
+  'lesen'
 ]
 'firstLineMatch': '^\\s*.*\\s*literate:\\s*syntax\\s*=\\s*(markdown|mdown|md)\\s*.*\\s*$'
 

--- a/grammars/literate.cson
+++ b/grammars/literate.cson
@@ -13,7 +13,7 @@
 
 'patterns': [
   {
-    'begin': '^(<<(coffee-?(script)?):([^>]+)>>=)\\s*$'
+    'begin': '^(<<(coffee-?(script)?):([^>]+)>>[\+]?=)\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.lterat'
@@ -32,7 +32,7 @@
     ]
   }
   {
-    'begin': '^<<(javascript|js):([^>]+)>>=\\s*$'
+    'begin': '^<<(javascript|js):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -51,7 +51,7 @@
     ]
   }
   {
-    'begin': '^<<(markdown|mdown|md):([^>]+)>>=\\s*$'
+    'begin': '^<<(markdown|mdown|md):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -69,7 +69,7 @@
     ]
   }
   {
-    'begin': '^<<(json):([^>]+)>>=\\s*$'
+    'begin': '^<<(json):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -88,7 +88,7 @@
     ]
   }
   {
-    'begin': '^<<(css):([^>]+)>>=\\s*$'
+    'begin': '^<<(css):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -107,7 +107,7 @@
     ]
   }
   {
-    'begin': '^<<(less):([^>]+)>>=\\s*$'
+    'begin': '^<<(less):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -126,7 +126,7 @@
     ]
   }
   {
-    'begin': '^<<(xml):([^>]+)>>=\\s*$'
+    'begin': '^<<(xml):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -145,7 +145,7 @@
     ]
   }
   {
-    'begin': '^<<(ruby|rb):([^>]+)>>=\\s*$'
+    'begin': '^<<(ruby|rb):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -164,7 +164,7 @@
     ]
   }
   {
-    'begin': '^<<(java):([^>]+)>>=\\s*$'
+    'begin': '^<<(java):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -183,7 +183,7 @@
     ]
   }
   {
-    'begin': '^<<(erlang):([^>]+)>>=\\s*$'
+    'begin': '^<<(erlang):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -202,7 +202,7 @@
     ]
   }
   {
-    'begin': '^<<(cs(harp)?):([^>]+)>>=\\s*$'
+    'begin': '^<<(cs(harp)?):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -221,7 +221,7 @@
     ]
   }
   {
-    'begin': '^<<(php):([^>]+)>>=\\s*$'
+    'begin': '^<<(php):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -240,7 +240,7 @@
     ]
   }
   {
-    'begin': '^<<(sh|bash):([^>]+)>>=\\s*$'
+    'begin': '^<<(sh|bash):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -259,7 +259,7 @@
     ]
   }
   {
-    'begin': '^<<(py(thon)?):([^>]+)>>=\\s*$'
+    'begin': '^<<(py(thon)?):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -278,7 +278,7 @@
     ]
   }
   {
-    'begin': '^<<(c):([^>]+)>>=\\s*$'
+    'begin': '^<<(c):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -297,7 +297,7 @@
     ]
   }
   {
-    'begin': '^<<(c(pp|\\+\\+)):([^>]+)>>=\\s*$'
+    'begin': '^<<(c(pp|\\+\\+)):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -319,7 +319,7 @@
     ]
   }
   {
-    'begin': '^<<(objc|objective-c):([^>]+)>>=\\s*$'
+    'begin': '^<<(objc|objective-c):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -338,7 +338,7 @@
     ]
   }
   {
-    'begin': '^<<(html):([^>]+)>>=\\s*$'
+    'begin': '^<<(html):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -357,7 +357,7 @@
     ]
   }
   {
-    'begin': '^<<(ya?ml):([^>]+)>>=\\s*$'
+    'begin': '^<<(ya?ml):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -376,7 +376,7 @@
     ]
   }
   {
-    'begin': '^<<(elixir):([^>]+)>>=\\s*$'
+    'begin': '^<<(elixir):([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -395,7 +395,7 @@
     ]
   }
   {
-    'begin': '^<<([^>]+)>>=\\s*$'
+    'begin': '^<<([^>]+)>>[\+]?=\\s*$'
     'beginCaptures':
       '0':
         'name': 'constant.language.literate'
@@ -439,7 +439,7 @@
         'name': 'markup.underline.link.literate'
   }
   'section-declaration': {
-    'match': '^<<([^>]+)>>=\\s*$'
+    'match': '^<<([^>]+)>>[\+]?=\\s*$'
     'name': 'link'
     'captures':
       '0':

--- a/grammars/literate.cson
+++ b/grammars/literate.cson
@@ -4,6 +4,8 @@
   'w'
   'nw'
   'noweb'
+  'lsn'
+  'lesen'
 ]
 'firstLineMatch': '^\\s*.*\\s*literate:.*\\s*$'
 


### PR DESCRIPTION
# Pull Request

Here are the two suggested changes. Please comment and let me know what you think, or what you would change.
## Add Support for Lesen

Lesen is a python reboot of noweb, but stripped down and not as fancy. The feature add is to include lesen file extensions with the `.nw` and other noweb file extensions.

I really don't care if this part is accepted - if needed, we can try to just cherry pick the other feature.
## Add Syntax Highlighting for <<...>>+=

In noweb and other literate 'languages' (tools), there is syntax for appending to a code block.

e.g.

```
<<js: hello world function>>=
function hello(text){
  var foo;
@

`foo` here is very important, and I want to interrupt the code block to discuss it.

<<js: hell world function>>+=
  // doesn't matter, just the rest of the inane example program
  if(text === 'world'){
    alert('hello world!');
  } else {
    foo = text;
  }
}
@

Here is the rest of the code chunk, which should be appended to the previous `js: hell world function` chunk.
```

Essentially, I want `<<js: hell world function>>+=` to highlight just like `<<js: hell world function>>=` does.
